### PR TITLE
Make `BiggerDecimal` extend `Serializable`

### DIFF
--- a/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
+++ b/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
@@ -16,7 +16,7 @@ import scala.annotation.tailrec
  * between positive and negative zeros (unlike `BigDecimal`), which may be useful in some
  * applications.
  */
-sealed abstract class BiggerDecimal {
+sealed abstract class BiggerDecimal extends Serializable {
   def isWhole: Boolean
   def isNegativeZero: Boolean
 


### PR DESCRIPTION
This PR makes `BiggerDecimal` extend `Serializable`. This should ensure that all ADT elements are fully `Serializable`, which is necessary for Spark friendliness (among other things).